### PR TITLE
Added a treatment of horizontal drag equivalent to the vertical

### DIFF
--- a/darthabrader.py
+++ b/darthabrader.py
@@ -191,7 +191,7 @@ def sediment_saltation(x0, scallop_elevation, w_water, u_water, u_w0, w_s, D, Hf
                 Re_p = particle_reynolds_number(D, urel, mu_kin)
                 drag_coef = dragcoeff(Re_p)
                 ax = -((3 * rho_w * drag_coef) * (urel**2) /(4 * rho_s * D))      
-                print('drag_coef_w', drag_coef)
+                print('urel_drag', drag_coef)
             else:
                 ax = 0
                 


### PR DESCRIPTION
In the free flow, it is reasonable to assume the particle has a very small delta U with the water. In the boundary layer where the water is changing directions, the relative horizontal velocity can change dramatically...

I am not confident this is implemented in a physically consistent way, so we could use some discussion about the simplifying assumptions of the Lamb model and whether we've broken them by adding physics. I don't recommend merging yet.

Also, fixed an underflow bug that ocurred when wrel was very small and then that very small number was squared. A likely source of our nondeterministic behavior and a definite cause of the "Nan in pi_x" bug that I had trapped but had not yet located. I will separately patch this fix to main.